### PR TITLE
[mysql] we need to allow for configurable (non)blocking collection of…

### DIFF
--- a/mysql/check.py
+++ b/mysql/check.py
@@ -529,7 +529,8 @@ class MySql(AgentCheck):
         if _is_affirmative(options.get('replication', False)):
             # Get replica stats
             results.update(self._get_replica_stats(db))
-            results.update(self._get_slave_status(db, above_560))
+            nonblocking = _is_affirmative(options.get('replication_non_blocking_status', False))
+            results.update(self._get_slave_status(db, above_560, nonblocking))
             metrics.update(REPLICA_VARS)
 
             # get slave running form global status page
@@ -863,7 +864,7 @@ class MySql(AgentCheck):
             self.warning("Privileges error getting replication status (must grant REPLICATION CLIENT): %s" % str(e))
             return {}
 
-    def _get_slave_status(self, db, above_560):
+    def _get_slave_status(self, db, above_560, nonblocking):
         """
         Retrieve the slaves' statuses using:
         1. The `performance_schema.threads` table. Non-blocking, requires version > 5.6.0
@@ -871,7 +872,7 @@ class MySql(AgentCheck):
         """
         try:
             with closing(db.cursor()) as cursor:
-                if above_560:
+                if above_560 and nonblocking:
                     # Query `performance_schema.threads` instead of `
                     # information_schema.processlist` to avoid mutex impact on performance.
                     cursor.execute("SELECT THREAD_ID, NAME FROM performance_schema.threads WHERE NAME LIKE '%worker'")

--- a/mysql/conf.yaml.example
+++ b/mysql/conf.yaml.example
@@ -13,6 +13,7 @@ instances:
     #   - optional_tag2
     # options:               # Optional
     #   replication: false
+    #   replication_non_blocking_status: false  # grab slave count in non-blocking manner (req. performance_schema)
     #   galera_cluster: false
     #   extra_status_metrics: true
     #   extra_innodb_metrics: true


### PR DESCRIPTION
… replicas statuses (#288)

* [mysql] configurable (non)blocking collection of replicas statuses.

* [mysql] default is blocking fashion to match former behavior.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
